### PR TITLE
test: increase test coverage of control characters in StringValue.escape

### DIFF
--- a/bundles/sirix-core/src/test/java/org/sirix/service/json/serializer/StringValueTest.java
+++ b/bundles/sirix-core/src/test/java/org/sirix/service/json/serializer/StringValueTest.java
@@ -8,22 +8,17 @@ import static org.junit.Assert.assertEquals;
 public final class StringValueTest {
 
   @Test
-  public void escapeFormfeed() {
+  public void escapeControlCharacters() {
     assertEquals("Form feed character '\\f' should be escaped", "\\f", StringValue.escape("\f"));
-  }
-
-  @Test
-  public void escapeTab() {
     assertEquals("Tab character '\\t' should be escaped", "\\t", StringValue.escape("\t"));
-  }
-
-  @Test
-  public void escapeBackspace() {
     assertEquals("Backspace character '\\b' should be escaped", "\\b", StringValue.escape("\b"));
+    assertEquals("Newline character '\\n' should be escaped", "\\n", StringValue.escape("\n"));
   }
 
   @Test
-  public void escapeEmoji() {
+  public void escapeUnicode() {
     assertEquals("Bomb emoji should not be escaped", "💣", StringValue.escape("💣"));
+    assertEquals("Heavy Check Mark emoji should not be escaped", "✔", StringValue.escape("✔"));
+    assertEquals("Special unicode should be escaped", "\\u20AB", StringValue.escape("₫"));
   }
 }


### PR DESCRIPTION
A few control characters were missing in the coverage so they are now tested.
Fixes soffan20/sirix#17