### PR TITLE
[WIP] Start work on a memory mapped file storage backend

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/access/ResourceConfiguration.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/ResourceConfiguration.java
@@ -137,7 +137,7 @@ public final class ResourceConfiguration {
 
   // FIXED STANDARD FIELDS
   /** Standard storage. */
-  private static final StorageType STORAGE = StorageType.FILE;
+  private static final StorageType STORAGE = StorageType.MEMORY_MAP;
 
   /** Standard versioning approach. */
   private static final VersioningType VERSIONING = VersioningType.SLIDING_SNAPSHOT;

--- a/bundles/sirix-core/src/main/java/org/sirix/io/StorageType.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/StorageType.java
@@ -24,6 +24,7 @@ import java.io.RandomAccessFile;
 import org.sirix.access.ResourceConfiguration;
 import org.sirix.exception.SirixIOException;
 import org.sirix.io.file.FileStorage;
+import org.sirix.io.file.MemoryMap;
 import org.sirix.io.ram.RAMStorage;
 
 /**
@@ -53,9 +54,11 @@ public enum StorageType {
   MEMORY_MAPPED_FILE {
     @Override
     public Storage getInstance(final ResourceConfiguration resourceConf) {
-      return null;
+      return new MemoryMap(resourceConf);
     }
   };
+
+
 
   /**
    * Get an instance of the storage backend.

--- a/bundles/sirix-core/src/main/java/org/sirix/io/file/FileReader.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/file/FileReader.java
@@ -55,25 +55,25 @@ public final class FileReader implements Reader {
   final static int FIRST_BEACON = 12;
 
   /** Beacon of the other references. */
-  final static int OTHER_BEACON = 4;
+  protected final static int OTHER_BEACON = 4;
 
   /** Inflater to decompress. */
-  final ByteHandler mByteHandler;
+  protected final ByteHandler mByteHandler;
 
   /** The hash function used to hash pages/page fragments. */
   final HashFunction mHashFunction;
 
   /** Data file. */
-  private final RandomAccessFile mDataFile;
+  protected final RandomAccessFile mDataFile;
 
   /** Revisions offset file. */
-  private final RandomAccessFile mRevisionsOffsetFile;
+  protected final RandomAccessFile mRevisionsOffsetFile;
 
   /** The type of data to serialize. */
-  private final SerializationType mType;
+  protected final SerializationType mType;
 
   /** Used to serialize/deserialze pages. */
-  private final PagePersister mPagePersiter;
+  protected final PagePersister mPagePersiter;
 
   /**
    * Constructor.

--- a/bundles/sirix-core/src/main/java/org/sirix/io/file/FileStorage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/file/FileStorage.java
@@ -44,16 +44,16 @@ import org.sirix.page.SerializationType;
 public final class FileStorage implements Storage {
 
   /** Data file name. */
-  private static final String FILENAME = "sirix.data";
+  protected static final String FILENAME = "sirix.data";
 
   /** Revisions file name. */
-  private static final String REVISIONS_FILENAME = "sirix.revisions";
+  protected static final String REVISIONS_FILENAME = "sirix.revisions";
 
   /** Instance to storage. */
-  private final Path mFile;
+  protected final Path mFile;
 
   /** Byte handler pipeline. */
-  private final ByteHandlePipeline mByteHandler;
+  protected final ByteHandlePipeline mByteHandler;
 
   /**
    * Constructor.
@@ -81,7 +81,7 @@ public final class FileStorage implements Storage {
     }
   }
 
-  private Path createDirectoriesAndFile() throws IOException {
+  protected Path createDirectoriesAndFile() throws IOException {
     final Path concreteStorage = getDataFilePath();
 
     if (!Files.exists(concreteStorage)) {
@@ -116,7 +116,7 @@ public final class FileStorage implements Storage {
    *
    * @return the path for this data file
    */
-  private Path getDataFilePath() {
+  public Path getDataFilePath() {
     return mFile.resolve(ResourceConfiguration.ResourcePaths.DATA.getPath()).resolve(FILENAME);
   }
 
@@ -125,7 +125,7 @@ public final class FileStorage implements Storage {
    *
    * @return the concrete storage for this database
    */
-  private Path getRevisionFilePath() {
+  protected Path getRevisionFilePath() {
     return mFile.resolve(ResourceConfiguration.ResourcePaths.DATA.getPath())
                 .resolve(REVISIONS_FILENAME);
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/io/file/FileWriter.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/file/FileWriter.java
@@ -50,16 +50,16 @@ import org.sirix.page.interfaces.Page;
 public final class FileWriter extends AbstractForwardingReader implements Writer {
 
   /** Random access to work on. */
-  private final RandomAccessFile mDataFile;
+  protected final RandomAccessFile mDataFile;
 
   /** {@link FileReader} reference for this writer. */
-  private final FileReader mReader;
+  protected final FileReader mReader;
 
-  private final SerializationType mType;
+  protected final SerializationType mType;
 
-  private final RandomAccessFile mRevisionsOffsetFile;
+  protected final RandomAccessFile mRevisionsOffsetFile;
 
-  private final PagePersister mPagePersister;
+  protected final PagePersister mPagePersister;
 
   /**
    * Constructor.
@@ -71,16 +71,16 @@ public final class FileWriter extends AbstractForwardingReader implements Writer
    * @param pagePersister transforms in-memory pages into byte-arrays and back
    */
   public FileWriter(final RandomAccessFile dataFile, final RandomAccessFile revisionsOffsetFile,
-      final ByteHandler handler, final SerializationType serializationType,
-      final PagePersister pagePersister) {
+                    final ByteHandler handler, final SerializationType serializationType,
+                    final PagePersister pagePersister) {
     mDataFile = checkNotNull(dataFile);
     mType = checkNotNull(serializationType);
     mRevisionsOffsetFile = mType == SerializationType.DATA
-        ? checkNotNull(revisionsOffsetFile)
-        : null;
+            ? checkNotNull(revisionsOffsetFile)
+            : null;
     mPagePersister = checkNotNull(pagePersister);
     mReader =
-        new FileReader(dataFile, revisionsOffsetFile, handler, serializationType, pagePersister);
+            new FileReader(dataFile, revisionsOffsetFile, handler, serializationType, pagePersister);
   }
 
   @Override
@@ -89,7 +89,7 @@ public final class FileWriter extends AbstractForwardingReader implements Writer
 
     while (uberPage.getRevisionNumber() != revision) {
       uberPage = (UberPage) mReader.read(
-          new PageReference().setKey(uberPage.getPreviousUberPageKey()), null);
+              new PageReference().setKey(uberPage.getPreviousUberPageKey()), null);
       if (uberPage.getRevisionNumber() == revision) {
         try {
           mDataFile.setLength(uberPage.getPreviousUberPageKey());
@@ -120,8 +120,8 @@ public final class FileWriter extends AbstractForwardingReader implements Writer
       final byte[] serializedPage;
 
       try (final ByteArrayOutputStream output = new ByteArrayOutputStream();
-          final DataOutputStream dataOutput =
-              new DataOutputStream(mReader.mByteHandler.serialize(output))) {
+           final DataOutputStream dataOutput =
+                   new DataOutputStream(mReader.mByteHandler.serialize(output))) {
         mPagePersister.serializePage(dataOutput, page, mType);
         dataOutput.flush();
         serializedPage = output.toByteArray();
@@ -137,8 +137,8 @@ public final class FileWriter extends AbstractForwardingReader implements Writer
       // Getting actual offset and appending to the end of the current file.
       final long fileSize = mDataFile.length();
       final long offset = fileSize == 0
-          ? FileReader.FIRST_BEACON
-          : fileSize;
+              ? FileReader.FIRST_BEACON
+              : fileSize;
       mDataFile.seek(offset);
       mDataFile.write(writtenPage);
 
@@ -167,6 +167,7 @@ public final class FileWriter extends AbstractForwardingReader implements Writer
       throw new SirixIOException(e);
     }
   }
+
 
   @Override
   public void close() throws SirixIOException {

--- a/bundles/sirix-core/src/main/java/org/sirix/io/file/MappedByteBufferHandler.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/file/MappedByteBufferHandler.java
@@ -1,0 +1,205 @@
+package org.sirix.io.file;
+
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+
+/**
+ * A handler for a MappedByteBuffer, used to keep track of written size and offset.
+ */
+public class MappedByteBufferHandler {
+    private MappedByteBuffer mappedByteBuffer = null;
+    private int size = 0;
+    private int offset = 0;
+
+    /**
+     * Creates a handler
+     * @param mappedByteBuffer the buffer to wrap.
+     * @param size the initial size
+     * @param offset the initial offset
+     */
+    public MappedByteBufferHandler(MappedByteBuffer mappedByteBuffer, int size, int offset){
+        this.mappedByteBuffer = mappedByteBuffer;
+        this.size = size;
+        this.offset = offset;
+    }
+
+    /**
+     * Used to replace the buffer, writes the original one to the hard drive.
+     * @param mappedByteBuffer the buffer which replaces the current one.
+     */
+    public void replaceBuffer(MappedByteBuffer mappedByteBuffer){
+        this.force();
+        this.mappedByteBuffer = mappedByteBuffer;
+    }
+
+    //Returns the limit of the underlying buffer.
+    public int limit(){
+        return mappedByteBuffer.limit();
+    }
+
+    /**
+     * Constructor
+     * @param mappedByteBuffer the underlying buffer
+     * @param size the inital size of the buffer.
+     */
+    public MappedByteBufferHandler(MappedByteBuffer mappedByteBuffer, int size){
+        this(mappedByteBuffer, size, 0);
+    }
+
+    /**
+     * Reads nBytes from the offset. The new offset will be the 'offset' given + the length of bytes read.
+     * @param offset the starting position to read from.
+     * @param nBytes the amount of bytes to read.
+     * @return the read bytes.
+     */
+    public byte[] read(int nBytes, int offset){
+        if(offset < 0 || nBytes < 0)
+            throw new IllegalArgumentException("Offset and nBytes must be not be negative");
+        //Offset can't be larger than size.
+        if(offset + nBytes >= size)
+            throw new IndexOutOfBoundsException("Offset + read bytes are larger than the size.");
+        byte[] readBytes = new byte[nBytes];
+
+        //Update the offset.
+        this.offset = offset;
+        mappedByteBuffer.position(offset);
+
+        for(int i = 0; i < nBytes; i++)
+            readBytes[i] = mappedByteBuffer.get();
+        return readBytes;
+    }
+
+    /**
+     * Reads nBytes from the offset. The new offset will be the 'offset' given + the length of bytes read.
+     * @param nBytes the amount of bytes to read.
+     * @return the read bytes.
+     */
+    public byte[] read(int nBytes){
+        return read(nBytes, offset);
+    }
+
+    /**
+     * Write dataToBeWritten to the file. The size of the file will increase if the 'offset' + 'dataToBeWritten.length' are larger than size.
+     * @param dataToBeWritten the bytes to write.
+     * @param offset the offset where to start writing from.
+     */
+    public void write(byte[] dataToBeWritten, int offset){
+        //We can't have negative offset.
+        if(offset < 0 || dataToBeWritten == null)
+            throw new IllegalArgumentException("Offset must be not be negative and dataToBeWritten most not be null.");
+
+        mappedByteBuffer.put(dataToBeWritten);
+
+        //Updates size.
+        size = Math.max(dataToBeWritten.length + offset, size);
+
+        //Updates offset.
+        offset = offset + dataToBeWritten.length;
+        mappedByteBuffer.position(offset);
+
+    }
+
+    /**
+     *
+     * @return the size of the function.
+     */
+    public int size(){
+        return size;
+    }
+
+    /**
+     *
+     * @return the current offset.
+     */
+    public int getOffset(){
+        return offset;
+    }
+
+    /**
+     * Write dataToBeWritten to the file. The size of the file will increase if the 'offset' + 'dataToBeWritten.length' are larger than size.
+     * @param dataToBeWritten the bytes to write.
+     */
+    public void write(byte[] dataToBeWritten){
+        write(dataToBeWritten, offset);
+    }
+
+    /**
+     * Writes a long to the file.
+     * @param longToBeWritten the long to be written.
+     * @param offset the offset to write from.
+     */
+    public void writeLong(long longToBeWritten, int offset){
+        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.putLong(longToBeWritten);
+        write(buffer.array(), offset);
+    }
+
+    /**
+     * Writes a long to the file.
+     * @param longToBeWritten the long to be written.
+     */
+    public void writeLong(long longToBeWritten){
+        writeLong(longToBeWritten, offset);
+    }
+
+    /**
+     * Read long from the file.
+     * @param offset the offset to read from.
+     * @return the long read from the file.
+     */
+    public long readLong(int offset){
+        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.put(read(8, offset));
+        buffer.flip();//need flip
+        return buffer.getLong();
+    }
+
+    /**
+     * Read a long
+     * @return the long read.
+     */
+    public long readLong(){
+        return readLong(offset);
+    }
+
+    /**
+     * Writes the size to the harddrive. Should not be used after this.
+     */
+    public void force(){
+        mappedByteBuffer.limit(size);
+        mappedByteBuffer.force();
+    }
+
+    /**
+     * Ses the current offset.
+     * @param offset the new offset.
+     */
+    public void setOffset(int offset){
+        this.offset = offset;
+    }
+
+    /**
+     * Reads an int from the file.
+     * @return the int read from the file.
+     */
+    public int readInt(){
+        return ByteBuffer.wrap(read(4)).getInt();
+    }
+
+    /**
+     * Reads a int from the file starting at the offset..
+     * @param offset the offset to start reading from
+     * @return the read int.
+     */
+    public int readInt(int offset){
+        return ByteBuffer.wrap(read(4,offset)).getInt();
+    }
+
+    /**
+     * Sets the size.
+     * @param size the new size.
+     */
+    public void setSize(int size){
+        this.size = size;
+    }
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/io/file/MemoryMap.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/file/MemoryMap.java
@@ -1,0 +1,162 @@
+package org.sirix.io.file;
+
+import org.sirix.access.ResourceConfiguration;
+import org.sirix.exception.SirixIOException;
+import org.sirix.io.Reader;
+import org.sirix.io.Storage;
+import org.sirix.io.Writer;
+import org.sirix.io.bytepipe.ByteHandlePipeline;
+import org.sirix.io.bytepipe.ByteHandler;
+import org.sirix.page.PagePersister;
+import org.sirix.page.SerializationType;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * This creates a virtual file which can be written and read to.
+ * Currently only supports up to 2 gb, due to limitation in how buffer works.
+ */
+public final class MemoryMap implements Storage {
+
+    RandomAccessFile dataFile = null;
+    RandomAccessFile revisionOffsetFile = null;
+    private FileStorage fileStorage = null;
+    private MappedByteBufferHandler mDataHandler = null;
+    private MappedByteBufferHandler mRevisionOffsetHandler = null;
+
+    /**
+     * The constructor
+     * @param resourceConfiguration the settings for the path to the file, revision file and their name and
+     *                              possible other settings.
+     * @throws SirixIOException thrown if an IOException occurs.
+     */
+    public MemoryMap(ResourceConfiguration resourceConfiguration) throws SirixIOException {
+        fileStorage = new FileStorage(resourceConfiguration);
+        try {
+            dataFile = new RandomAccessFile(fileStorage.createDirectoriesAndFile().toFile(), "rw");
+            revisionOffsetFile = new RandomAccessFile(FileStorage.REVISIONS_FILENAME, "rw");
+
+            FileChannel dataFileChannel = dataFile.getChannel();
+            MappedByteBuffer temp = dataFileChannel.map(FileChannel.MapMode.READ_WRITE, 0, dataFile.length());
+            mDataHandler = new MappedByteBufferHandler(temp, (int) dataFileChannel.size());
+
+            FileChannel revisionOffsetChannel = revisionOffsetFile.getChannel();
+            temp = revisionOffsetChannel.map(FileChannel.MapMode.READ_WRITE, 0, revisionOffsetFile.length());
+            mRevisionOffsetHandler = new MappedByteBufferHandler(temp, (int) revisionOffsetChannel.size());
+        } catch (final IOException e) {
+            throw new SirixIOException(e);
+        }
+    }
+
+
+    /**
+     * Creates a reader for reading the file and possible the revision file.
+     * @return a MemoryMapReader, for reading the file and revision file.
+     * @throws SirixIOException if an IOException occurs.
+     */
+    @Override
+    public Reader createReader() throws SirixIOException {
+        try {
+            final Path dataFilePath = fileStorage.createDirectoriesAndFile();
+            final Path revisionsOffsetFilePath = fileStorage.getRevisionFilePath();
+
+            return new MemoryMapReader(new RandomAccessFile(dataFilePath.toFile(), "r"),
+                    new RandomAccessFile(revisionsOffsetFilePath.toFile(), "r"),
+                    new ByteHandlePipeline(fileStorage.mByteHandler), SerializationType.DATA, new PagePersister(),
+                    mDataHandler, mRevisionOffsetHandler);
+
+        } catch (final IOException e) {
+            throw new SirixIOException(e);
+        }
+    }
+
+    /**
+     * Creates a writer for reading and writing to the file and revision file.
+     * @return a MemoryMapWriter.
+     * @throws SirixIOException if an IOException occurs.
+     */
+    @Override
+    public Writer createWriter() throws SirixIOException {
+        try {
+            final Path dataFilePath = fileStorage.createDirectoriesAndFile();
+            final Path revisionsOffsetFilePath = fileStorage.getRevisionFilePath();
+
+            return new MemoryMapWriter(new RandomAccessFile(dataFilePath.toFile(), "rw"),
+                    new RandomAccessFile(revisionsOffsetFilePath.toFile(), "rw"),
+                    new ByteHandlePipeline(fileStorage.mByteHandler), SerializationType.DATA, new PagePersister(),
+                    mDataHandler, mRevisionOffsetHandler, this);
+        } catch (final IOException e) {
+            throw new SirixIOException(e);
+        }
+    }
+
+    /**
+     * This function is not and should not be used.
+     */
+    @Override
+    public void close() {
+    }
+
+    /**
+     * Check if the underlying file actually exists.
+     * @return true if it exists, otherwise false.
+     * @throws SirixIOException if an IOException occurs.
+     */
+    @Override
+    public boolean exists() throws SirixIOException {
+        final Path storage = fileStorage.getDataFilePath();
+        try {
+            return Files.exists(storage) && Files.size(storage) > 0;
+        } catch (final IOException e) {
+            throw new SirixIOException(e);
+        }
+    }
+
+    /**
+     *
+     * @return the bytehandler for the file.
+     */
+    @Override
+    public ByteHandler getByteHandler() {
+        return fileStorage.mByteHandler;
+    }
+
+    /**
+     * Updates the size of the buffer limit is too small. It writes to the file in the normal memory
+     * in the process of doing this. Increases the size by a factor of a power of 2, ex 2 times larger or 4 times
+     * larger.
+     * @param handler The handler sent in, should either be datahandler or the revisionoffsethandler.
+     * @param limit How much memory the new buffer needs at least.
+     * @return the new handler sent in.
+     */
+    public MappedByteBufferHandler updateSize(MappedByteBufferHandler handler, long limit) {
+        MappedByteBufferHandler newHandler;
+        RandomAccessFile fileToUpdateHandlerWith;
+        if (handler.equals(mDataHandler)) {
+            newHandler = mDataHandler;
+            fileToUpdateHandlerWith = dataFile;
+        } else {
+            newHandler = mRevisionOffsetHandler;
+            fileToUpdateHandlerWith = revisionOffsetFile;
+        }
+        try {
+            int oldSize = (int) newHandler.size();
+            int newSize = oldSize;
+            while (newSize < limit) {
+                newSize = 2 * oldSize;
+            }
+            FileChannel newChannel = fileToUpdateHandlerWith.getChannel();
+            MappedByteBuffer temp = newChannel.map(FileChannel.MapMode.READ_WRITE, 0, dataFile.length());
+            newHandler.replaceBuffer(temp);
+        } catch (final IOException e) {
+            throw new SirixIOException(e);
+        }
+        return newHandler;
+    }
+
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/io/file/MemoryMapReader.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/file/MemoryMapReader.java
@@ -1,0 +1,137 @@
+package org.sirix.io.file;
+
+import org.sirix.api.PageReadOnlyTrx;
+import org.sirix.exception.SirixIOException;
+import org.sirix.io.bytepipe.ByteHandler;
+import org.sirix.io.Reader;
+import org.sirix.page.*;
+import org.sirix.page.interfaces.Page;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+
+/**
+ * The reader for the memory map file. Can not handle reading files larger than 2 Gb.
+ */
+public class MemoryMapReader implements Reader {
+
+    private FileReader fileReader = null;
+    private MappedByteBufferHandler mDataBuffer = null;
+    private MappedByteBufferHandler mRevisionOffsetBuffer = null;
+
+    /**
+     * Constructor,
+     * @param dataFile the underlying datafile.
+     * @param revisionsOffsetFile the underlying revision file.
+     * @param handler Needed for FileReader, which lacks documentation
+     * @param serializationType Needed for FileReader, which lacks documentation
+     * @param pagePersister Needed for FileReader, which lacks documentation
+     * @param dataBuffer Needed to make sure the files are synchronized.
+     * @param revisionOffsetBuffer Needed to make sure the files are syncrhonized.
+     */
+    public MemoryMapReader(final RandomAccessFile dataFile, final RandomAccessFile revisionsOffsetFile,
+                           final ByteHandler handler, final SerializationType serializationType,
+                           final PagePersister pagePersister, MappedByteBufferHandler dataBuffer,
+                           MappedByteBufferHandler revisionOffsetBuffer) {
+
+        fileReader = new FileReader(dataFile, revisionsOffsetFile, handler, serializationType, pagePersister);
+        this.mDataBuffer = dataBuffer;
+        this.mRevisionOffsetBuffer = revisionOffsetBuffer;
+    }
+
+    /**
+     * Should behave the same as the FileReader readUberPageReference. Due to lack of documentation, we are not
+     * exactly how sure file readers behaves.
+     * @return
+     * @throws SirixIOException
+     */
+    @Override
+    public PageReference readUberPageReference() throws SirixIOException {
+        final PageReference uberPageReference = new PageReference();
+        // Read primary beacon.
+        uberPageReference.setKey(mDataBuffer.readLong(0));
+
+        final UberPage page = (UberPage) read(uberPageReference, null);
+        uberPageReference.setPage(page);
+        return uberPageReference;
+    }
+
+    /**
+     * Should mirror the behavior of the FileReaders read function, reads from the file. Due to lack of documentation,
+     * so are we not exactly what it's parameters does or what it returns.
+     * @param reference
+     * @param pageReadTrx {@link PageReadOnlyTrx} reference
+     * @return
+     */
+    @Override
+    public Page read(@Nonnull PageReference reference, @Nullable PageReadOnlyTrx pageReadTrx) {
+        try {
+            // Read page from file.
+            switch (fileReader.mType) {
+                case DATA:
+                    mDataBuffer.setOffset((int)reference.getKey());
+                    break;
+                case TRANSACTION_INTENT_LOG:
+                    mDataBuffer.setOffset((int) reference.getPersistentLogKey());
+                    break;
+                default:
+                    assert false; //Should not come here.
+            }
+            final int dataLength = mDataBuffer.readInt();
+            reference.setLength(dataLength + FileReader.OTHER_BEACON);
+            final byte[] page = new byte[dataLength];
+
+            // Perform byte operations.
+            final DataInputStream input =
+                    new DataInputStream(fileReader.mByteHandler.deserialize(new ByteArrayInputStream(page)));
+
+            // Return reader required to instantiate and deserialize page.
+            return fileReader.mPagePersiter.deserializePage(input, pageReadTrx, fileReader.mType);
+        } catch (final IOException e) {
+            throw new SirixIOException(e);
+        }
+    }
+
+    /**
+     * Writes the virtual file to the harddrive. The reader should not be used after this.
+     * @throws SirixIOException If it gets an IOException
+     */
+    @Override
+    public void close() throws SirixIOException {
+        mDataBuffer.force();
+        mRevisionOffsetBuffer.force();
+        fileReader.close();
+    }
+
+    /**
+     * Should function identical as the fileReaders but with the virtual file. Due to lack of documentation
+     * so can't we for certain say what the parameters does.
+     * @param revision the revision to read
+     * @param pageReadTrx the page reading transaction
+     * @return
+     */
+    @Override
+    public RevisionRootPage readRevisionRootPage(int revision, PageReadOnlyTrx pageReadTrx) {
+        try {
+            mRevisionOffsetBuffer.setOffset(revision*8);
+            long positionToStartReadingFrom = mRevisionOffsetBuffer.readLong();
+
+            mDataBuffer.setOffset((int)positionToStartReadingFrom);
+            final int dataLength = mDataBuffer.readInt();
+            final byte[] page = mDataBuffer.read(dataLength);
+
+            // Perform byte operations.
+            final DataInputStream input =
+                    new DataInputStream(fileReader.mByteHandler.deserialize(new ByteArrayInputStream(page)));
+
+            // Return reader required to instantiate and deserialize page.
+            return (RevisionRootPage) fileReader.mPagePersiter.deserializePage(input, pageReadTrx, fileReader.mType);
+        } catch (IOException e) {
+            throw new SirixIOException(e);
+        }
+    }
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/io/file/MemoryMapWriter.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/file/MemoryMapWriter.java
@@ -1,0 +1,220 @@
+package org.sirix.io.file;
+
+import org.sirix.api.PageReadOnlyTrx;
+import org.sirix.exception.SirixIOException;
+import org.sirix.io.Writer;
+import org.sirix.io.bytepipe.ByteHandler;
+import org.sirix.io.file.FileReader;
+import org.sirix.io.file.FileWriter;
+import org.sirix.page.*;
+import org.sirix.page.interfaces.Page;
+import org.sirix.io.Writer;
+
+import javax.annotation.Nullable;
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+
+/**
+ * The writer for the memory mapped file.
+ */
+public class MemoryMapWriter implements Writer {
+    private MemoryMapReader mReader;
+    private MappedByteBufferHandler mDataBuffer = null;
+    private MappedByteBufferHandler mRevisionOffsetBuffer = null;
+    private MemoryMap parent;
+
+    private FileWriter fileWriter = null;
+
+    /**
+     * Constructor,
+     * @param dataFile the underlying datafile.
+     * @param revisionsOffsetFile the underlying revision file.
+     * @param handler Needed for FileWriter, which lacks documentation
+     * @param serializationType Needed for FileWriter, which lacks documentation
+     * @param pagePersister Needed for FileWriter, which lacks documentation
+     * @param dataBuffer Needed to make sure the files are synchronized.
+     * @param revisionOffsetBuffer Needed to make sure the files are syncrhonized.
+     * @param parent The memory map which created this writer.
+     */
+    public MemoryMapWriter(final RandomAccessFile dataFile, final RandomAccessFile revisionsOffsetFile,
+                           final ByteHandler handler, final SerializationType serializationType,
+                           final PagePersister pagePersister, MappedByteBufferHandler dataBuffer,
+                           MappedByteBufferHandler revisionOffsetBuffer, MemoryMap parent) {
+
+        fileWriter = new FileWriter(dataFile, revisionsOffsetFile, handler, serializationType, pagePersister);
+        this.mDataBuffer = dataBuffer;
+        this.mRevisionOffsetBuffer = revisionOffsetBuffer;
+        this.parent = parent;
+
+
+        mReader = new MemoryMapReader(dataFile,revisionsOffsetFile,handler,serializationType,pagePersister, dataBuffer, revisionOffsetBuffer);
+    }
+
+    /**
+     * Writes to the underlying file.
+     * @param pageReference that points to a page
+     * @return this writer.
+     * @throws SirixIOException in case of IOException
+     */
+    @Override
+    public Writer write(PageReference pageReference) throws SirixIOException {
+
+        // Perform byte operations.
+        try {
+            // Serialize page.
+            final Page page = pageReference.getPage();
+            assert page != null;
+
+            final byte[] serializedPage;
+
+            try (final ByteArrayOutputStream output = new ByteArrayOutputStream();
+                 final DataOutputStream dataOutput =
+                         new DataOutputStream(fileWriter.mReader.mByteHandler.serialize(output))) {
+                fileWriter.mPagePersister.serializePage(dataOutput, page, fileWriter.mType);
+                dataOutput.flush();
+                serializedPage = output.toByteArray();
+            }
+
+            final byte[] writtenPage = new byte[serializedPage.length + FileReader.OTHER_BEACON];
+            final ByteBuffer buffer = ByteBuffer.allocate(writtenPage.length);
+            buffer.putInt(serializedPage.length);
+            buffer.put(serializedPage);
+            buffer.position(0);
+            buffer.get(writtenPage, 0, writtenPage.length);
+
+            // Getting actual offset and appending to the end of the current file.
+            final long fileSize = mDataBuffer.size();
+            final long offset = fileSize == 0
+                    ? FileReader.FIRST_BEACON
+                    : fileSize;
+
+            if(mDataBuffer.limit() < offset + writtenPage.length)
+                parent.updateSize(mDataBuffer, offset + writtenPage.length);
+            mDataBuffer.write(writtenPage, (int) offset);
+            // Remember page coordinates.
+            switch (fileWriter.mType) {
+                case DATA:
+                    pageReference.setKey(offset);
+                    break;
+                case TRANSACTION_INTENT_LOG:
+                    pageReference.setPersistentLogKey(offset);
+                    break;
+                default:
+                    assert false; //Should never happen
+            }
+
+            pageReference.setLength(writtenPage.length);
+            pageReference.setHash(fileWriter.mReader.mHashFunction.hashBytes(writtenPage).asBytes());
+
+            if (fileWriter.mType == SerializationType.DATA && page instanceof RevisionRootPage) {
+                if(mRevisionOffsetBuffer.limit() < 8 + offset)
+                    parent.updateSize(mRevisionOffsetBuffer, 8 + offset);
+                mRevisionOffsetBuffer.writeLong(offset);
+            }
+
+            return this;
+        } catch (final IOException e) {
+            throw new SirixIOException(e);
+        }
+    }
+
+    /**
+     * This function should mirror the functionality of the FileWriter. Due to the lack of documentation, so is it
+     * not clear exactly what the parameters does.
+     * @param pageReference that points to the beacon
+     * @return
+     * @throws SirixIOException
+     */
+    @Override
+    public Writer writeUberPageReference(PageReference pageReference) throws SirixIOException {
+        write(pageReference);
+        mDataBuffer.writeLong(pageReference.getKey(), 0);
+        return this;
+    }
+
+    /**
+     * This function should mirror the functionality of the FileWriter. Due to the lack of documentation, so is it
+     * not clear exactly what the parameters does.
+     * @param revision
+     * @return this writer
+     * @throws SirixIOException in case of IOException
+     */
+    @Override
+    public Writer truncateTo(int revision) {
+
+        UberPage uberPage = (UberPage) mReader.readUberPageReference().getPage();
+
+        while (uberPage.getRevisionNumber() != revision) {
+            uberPage = (UberPage) mReader.read(
+                    new PageReference().setKey(uberPage.getPreviousUberPageKey()), null);
+            if (uberPage.getRevisionNumber() == revision) {
+
+                mDataBuffer.setSize((int) uberPage.getPreviousUberPageKey());
+
+                break;
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * This function should mirror the functionality of the FileWriter. Due to the lack of documentation, so is it
+     * not clear exactly what the parameters does.
+     * @return this writer.
+     */
+    @Override
+    public Writer truncate() {
+        mDataBuffer.setSize(0);
+        mRevisionOffsetBuffer.setSize(0);
+        return this;
+    }
+
+    /**
+     * This function should mirror the functionality of the FileWriter. Due to the lack of documentation, so is it
+     * not clear exactly what the parameters does.
+     * @return
+     * @throws SirixIOException
+     */
+    @Override
+    public PageReference readUberPageReference() throws SirixIOException {
+        return mReader.readUberPageReference();
+    }
+
+    /**
+     * Reads from the object. Should function identically to how read works for FileWriter. Due to lack of
+     * documentation for FileWriter, so do we not know how the parameters and return values work.
+     * @param key the reference for the page to be determined
+     * @param pageReadTrx {@link PageReadOnlyTrx} reference
+     * @return
+     * @throws SirixIOException
+     */
+    @Override
+    public Page read(PageReference key, @Nullable PageReadOnlyTrx pageReadTrx) throws SirixIOException {
+        return mReader.read(key, pageReadTrx);
+    }
+
+    /**
+     * Closes the writer and writes the file to the harddrive. The writer should not be used after this.
+     * @throws SirixIOException if an IOException occurs.
+     */
+    @Override
+    public void close() throws SirixIOException {
+        mDataBuffer.force();
+        mRevisionOffsetBuffer.force();
+    }
+
+    /**
+     * Should mirror the functionality of the FileWriter, due to lack of documentation, so are we not sure
+     * exactly what the parameters and return are.
+     * @param revision the revision to read
+     * @param pageReadTrx the page reading transaction
+     * @return
+     */
+    @Override
+    public RevisionRootPage readRevisionRootPage(int revision, PageReadOnlyTrx pageReadTrx) {
+        return mReader.readRevisionRootPage(revision, pageReadTrx);
+    }
+}


### PR DESCRIPTION
The current implementation will do all read/writes directly to disc when
managing the database. The main idea with this implementation is to use
MappedByteBuffer which will load a file into memory that can be accessed
faster. The current implementation status is that it is functionally
finished but not usable due to bugs.

Fixes soffan20/sirix#62
Fixes soffan20/sirix#63
Fixes soffan20/sirix#66